### PR TITLE
Filter category tree by store

### DIFF
--- a/src/FondOfSpryker/Zed/CategoryExtendStorage/Business/Storage/CategoryTreeExtendStorage.php
+++ b/src/FondOfSpryker/Zed/CategoryExtendStorage/Business/Storage/CategoryTreeExtendStorage.php
@@ -2,6 +2,8 @@
 
 namespace FondOfSpryker\Zed\CategoryExtendStorage\Business\Storage;
 
+use Generated\Shared\Transfer\CategoryTreeStorageTransfer;
+use Orm\Zed\CategoryStorage\Persistence\SpyCategoryTreeStorage;
 use Spryker\Shared\Kernel\Store;
 use Spryker\Zed\CategoryStorage\Business\Storage\CategoryTreeStorage as SprykerCategoryTreeStorage;
 use Spryker\Zed\CategoryStorage\Dependency\Service\CategoryStorageToUtilSanitizeServiceInterface;
@@ -49,4 +51,68 @@ class CategoryTreeExtendStorage extends SprykerCategoryTreeStorage
 
         return $categoryStorageEntitiesByLocale;
     }
+
+    /**
+     * @return array
+     */
+    protected function getCategoryTrees()
+    {
+        $currentStoreId = $this->storeFacade->getCurrentStore()->getIdStore();
+        $localeNames = $this->getSharedPersistenceLocaleNames();
+        $locales = $this->queryContainer->queryLocalesWithLocaleNames($localeNames)->find();
+
+        $rootCategory = $this->queryContainer->queryCategoryRoot()->filterByFkStore($currentStoreId)->findOne();
+        $categoryNodeTree = [];
+        $this->disableInstancePooling();
+        foreach ($locales as $locale) {
+            $categoryNodes = $this->queryContainer->queryCategoryNodeTree($locale->getIdLocale())->filterByFkStore($currentStoreId)->find()->getData();
+            $categoryNodeTree[$locale->getLocaleName()] = $this->getChildren($rootCategory->getIdCategoryNode(),
+                $categoryNodes);
+        }
+        $this->enableInstancePooling();
+
+        foreach ($categoryNodeTree as $key => $data) {
+            if (count($data) === 0) {
+                unset($categoryNodeTree[$key]);
+            }
+        }
+
+        return $categoryNodeTree;
+    }
+
+    /**
+     * @param  \Generated\Shared\Transfer\CategoryNodeStorageTransfer[]  $categoryNodeStorageTransfers
+     * @param  string  $localeName
+     * @param  \Orm\Zed\CategoryStorage\Persistence\SpyCategoryTreeStorage|null  $spyCategoryTreeStorage
+     *
+     * @return void
+     */
+    protected function storeDataSet(
+        array $categoryNodeStorageTransfers,
+        $localeName,
+        ?SpyCategoryTreeStorage $spyCategoryTreeStorage = null
+    ) {
+        if ($spyCategoryTreeStorage === null) {
+            $spyCategoryTreeStorage = new SpyCategoryTreeStorage();
+        }
+
+        $spyCategoryTreeStorage->setStore($this->storeFacade->getCurrentStore()->getName());
+        parent::storeDataSet($categoryNodeStorageTransfers, $localeName, $spyCategoryTreeStorage);
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getSharedPersistenceLocaleNames(): array
+    {
+        $localeNames = $this->store->getLocales();
+        foreach ($this->store->getStoresWithSharedPersistence() as $storeName) {
+            foreach ($this->store->getLocalesPerStore($storeName) as $localeName) {
+                $localeNames[] = $localeName;
+            }
+        }
+
+        return array_unique($localeNames);
+    }
+
 }


### PR DESCRIPTION
This PR fixes a problem where the category tree won't build properly with multiple stores. 
Category trees are now filtered by store foreign key and the data entry should be filled correctly.